### PR TITLE
makes sure that images don't mess up the viewport

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -19,6 +19,10 @@ body {
   line-height: 160%;
 }
 
+img {
+  max-width: 100%;
+}
+
 a,
 a:active {
   color: #606;


### PR DESCRIPTION
If they're limited to 100% wide, then it's possible to have a more responsive experience.