### PR TITLE
fix title line height

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -64,6 +64,7 @@ h1 {
 h1.page-title {
   font-size: 48px;
   margin: 1em 30px;
+  line-height: 100%;
 }
 
 h2 {


### PR DESCRIPTION
Line height is not correct when the title is long. It looks like this:  
![screen shot 2016-09-19 at 2 55 55 pm](https://cloud.githubusercontent.com/assets/6128372/18625506/47a82ff6-7e79-11e6-9fc6-7c3451d0407b.png)
This simple fix to make it looks like this:  
![screen shot 2016-09-19 at 2 57 20 pm](https://cloud.githubusercontent.com/assets/6128372/18625547/78bb280a-7e79-11e6-8197-64ea5fcbad6f.png)
