### PR TITLE
Update publish.js to check example is not undefined

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -448,7 +448,7 @@ exports.publish = function(taffyData, opts, tutorials) {
             doclet.examples = doclet.examples.map(function(example) {
                 var caption, code;
 
-                if (example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
+                if (example && example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
                     caption = RegExp.$1;
                     code = RegExp.$3;
                 }


### PR DESCRIPTION
is example is undefined then this will suppress this error and allow the generation of the out files to continue. :

```
Generating output files...
/usr/local/lib/node_modules/docdash/publish.js:451
                if (example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
                           ^

TypeError: Cannot read property 'match' of undefined
    at /usr/local/lib/node_modules/docdash/publish.js:451:28
    at Array.map (native)
    at /usr/local/lib/node_modules/docdash/publish.js:448:47
    at each (/usr/local/lib/node_modules/jsdoc/node_modules/taffydb/taffy.js:87:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/jsdoc/node_modules/taffydb/taffy.js:1109:7)
    at Object.API.(anonymous function) [as each] (/usr/local/lib/node_modules/jsdoc/node_modules/taffydb/taffy.js:127:18)
    at Object.exports.publish (/usr/local/lib/node_modules/docdash/publish.js:444:12)
    at Object.module.exports.cli.generateDocs (/usr/local/lib/node_modules/jsdoc/cli.js:430:39)
    at Object.module.exports.cli.processParseResults (/usr/local/lib/node_modules/jsdoc/cli.js:383:20)
    at module.exports.cli.main (/usr/local/lib/node_modules/jsdoc/cli.js:227:14)
    at Object.module.exports.cli.runCommand (/usr/local/lib/node_modules/jsdoc/cli.js:180:5)
    at /usr/local/lib/node_modules/jsdoc/jsdoc.js:103:9
    at Object.<anonymous> (/usr/local/lib/node_modules/jsdoc/jsdoc.js:104:3)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)