### PR TITLE
Add support for @sig and @category tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-node_modules
+/node_modules
+/.idea
 *.sublime-project
 *.sublime-workspace
 .DS_Store

--- a/fixtures/fixtures.conf.json
+++ b/fixtures/fixtures.conf.json
@@ -1,4 +1,5 @@
 {
+    "title": "Ramda Adjunct",
     "tags": {
         "allowUnknownTags": true
     },
@@ -14,7 +15,8 @@
         "template": "../",
         "destination": "../fixtures-doc/",
         "recurse": true,
-        "verbose": true
+        "verbose": true,
+        "package": "package.json"
     },
     "markdown": {
         "parser": "gfm",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "A clean, responsive documentation template theme for JSDoc 3 inspired by lodash and minami",
   "main": "publish.js",
   "scripts": {
+    "test": "better-npm-run test",
+    "sync": "better-npm-run sync",
+    "watch": "better-npm-run watch"
+  },
+  "betterScripts": {
     "test": "jsdoc -c fixtures/fixtures.conf.json",
     "sync": "browser-sync start -s ../fixtures-doc -f ../fixtures-doc --reload-delay 1000 --no-ui --no-notify",
     "watch": "watch-run -d 1000 -p tmpl/**,static/** \"npm run test\""
@@ -15,7 +20,8 @@
   "devDependencies": {
     "jsdoc": "latest",
     "browser-sync": "latest",
-    "watch-run": "latest"
+    "watch-run": "latest",
+    "better-npm-run": "=0.0.14"
   },
   "author": "Clement Moron <clement.moron@gmail.com>",
   "license": "Apache-2.0",

--- a/publish.js
+++ b/publish.js
@@ -407,10 +407,12 @@ function buildHeader() {
   var indexUrl = 'index.html';
   var githubUrl = env.conf.github;
   var gitterUrl = env.conf.gitter;
-  var header = '';
+  var latestUrl = env.conf.latest;
 
+  var header = '';
   header += '<a href="' + indexUrl + '"><strong>' + title + '</strong></a>';
   header += '<ul>';
+  header += '<li><a href="' + latestUrl +  '">Latest Docs</a></li>';
   header += '<li><a href="' + githubUrl +  '">GitHub</a></li>';
   header += '<li><a href="' + gitterUrl + '">Discuss</a></li>';
   header += '</ul>';

--- a/publish.js
+++ b/publish.js
@@ -317,7 +317,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                     itemsNav += "</ul>";
                 }
 
-                if (methods.length) {
+                if (methods.length && itemHeading !== 'Classes') {
                     itemsNav += "<ul class='methods'>";
 
                     methods.forEach(function (method) {

--- a/publish.js
+++ b/publish.js
@@ -408,10 +408,12 @@ function buildHeader() {
   var githubUrl = env.conf.github;
   var gitterUrl = env.conf.gitter;
   var latestUrl = env.conf.latest;
+  var tryUrl = env.conf.try;
 
   var header = '';
   header += '<a href="' + indexUrl + '"><strong>' + title + '</strong></a>';
   header += '<ul>';
+  header += '<li><a href="' + tryUrl +  '">Try</a></li>';
   header += '<li><a href="' + latestUrl +  '">Latest Docs</a></li>';
   header += '<li><a href="' + githubUrl +  '">GitHub</a></li>';
   header += '<li><a href="' + gitterUrl + '">Discuss</a></li>';

--- a/publish.js
+++ b/publish.js
@@ -362,12 +362,13 @@ function linktoExternal(longName, name) {
  * @param {array<object>} members.tutorials
  * @param {array<object>} members.events
  * @param {array<object>} members.interfaces
- * @return {s
- ring} The HTML for the navigation sidebar.
+ * @return {string} The HTML for the navigation sidebar.
  */
 
 function buildNav(members) {
-    var nav = '<h2><a href="index.html">Home</a></h2>';
+    var packageInfo = ( find({kind: 'package'}) || [] ) [0];
+    var title = (env.conf.title || 'Home') +  ' ' + (packageInfo && packageInfo.version || '');
+    var nav = '<h2><a href="index.html">' + title + '</a></h2>';
     var seen = {};
     var seenTutorials = {};
 
@@ -604,8 +605,9 @@ exports.publish = function(taffyData, opts, tutorials) {
     // index page displays information from package.json and lists files
     var files = find({kind: 'file'});
     var packages = find({kind: 'package'});
+    var moduleName = (env.conf.title || 'Home') +  ' ' + (packageInfo && packageInfo.version || '');
 
-    generate('', 'Home',
+  generate('', moduleName,
         packages.concat(
             [{kind: 'mainpage', readme: opts.readme, longname: (opts.mainpagetitle) ? opts.mainpagetitle : 'Main Page'}]
         ).concat(files),

--- a/publish.js
+++ b/publish.js
@@ -366,9 +366,7 @@ function linktoExternal(longName, name) {
  */
 
 function buildNav(members) {
-    var packageInfo = ( find({kind: 'package'}) || [] ) [0];
-    var title = (env.conf.title || 'Home') +  ' ' + (packageInfo && packageInfo.version || '');
-    var nav = '<h2><a href="index.html">' + title + '</a></h2>';
+    var nav = '';
     var seen = {};
     var seenTutorials = {};
 
@@ -376,7 +374,7 @@ function buildNav(members) {
     nav += buildMemberNav(members.modules, 'Modules', {}, linkto);
     nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);
     nav += buildMemberNav(members.events, 'Events', seen, linkto);
-    nav += buildMemberNav(members.namespaces, 'Namespaces', seen, linkto);
+    nav += buildMemberNav(members.namespaces, '', seen, linkto);
     nav += buildMemberNav(members.mixins, 'Mixins', seen, linkto);
     nav += buildMemberNav(members.tutorials, 'Tutorials', seenTutorials, linktoTutorial);
     nav += buildMemberNav(members.interfaces, 'Interfaces', seen, linkto);
@@ -401,6 +399,23 @@ function buildNav(members) {
     }
 
     return nav;
+}
+
+function buildHeader() {
+  var packageInfo = ( find({kind: 'package'}) || [] ) [0];
+  var title = (env.conf.title || 'Home') +  ' ' + (packageInfo && packageInfo.version || '');
+  var indexUrl = 'index.html';
+  var githubUrl = env.conf.github;
+  var gitterUrl = env.conf.gitter;
+  var header = '';
+
+  header += '<a href="' + indexUrl + '"><strong>' + title + '</strong></a>';
+  header += '<ul>';
+  header += '<li><a href="' + githubUrl +  '">GitHub</a></li>';
+  header += '<li><a href="' + gitterUrl + '">Discuss</a></li>';
+  header += '</ul>';
+
+  return header;
 }
 
 /**
@@ -591,6 +606,7 @@ exports.publish = function(taffyData, opts, tutorials) {
 
     // once for all
     view.nav = buildNav(members);
+    view.header = buildHeader();
     attachModuleSymbols( find({ longname: {left: 'module:'} }), members.modules );
 
     // generate the pretty-printed source files first so other pages can link to them

--- a/publish.js
+++ b/publish.js
@@ -42,6 +42,15 @@ function hashToLink(doclet, hash) {
     return '<a href="' + url + '">' + hash + '</a>';
 }
 
+function categoryLink(methodLongName, methodName, category) {
+    var url = linkto(methodLongName, methodName);
+    const label = '<span data-category="List" class="label label-category">' + category + '</span>';
+
+    url = url.replace(/(<\/a>)$/, label + ' $1');
+
+    return url;
+}
+
 function needsSignature(doclet) {
     var needsSig = false;
 
@@ -322,7 +331,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
 
                     methods.forEach(function (method) {
                         itemsNav += "<li data-type='method'>";
-                        itemsNav += linkto(method.longname, method.name);
+                        itemsNav += categoryLink(method.longname, method.name, method.category);
                         itemsNav += "</li>";
                     });
 

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -1,0 +1,26 @@
+$(document).ready(function() {
+  var filterInput = $(this).find('#filter input');
+  var categoryLabel = $(this).find('.label.label-category');
+
+  filterInput.on('input', function() {
+     var val = $(this).val().toLowerCase();
+
+     $('nav > ul:nth-of-type(2) ul li').each(function(index, el) {
+       var li = $(el);
+       var liText = li.text().toLowerCase();
+
+       if (liText.indexOf(val) === -1) {
+        li.hide();
+       } else {
+        li.show();
+       }
+    });
+  });
+
+  categoryLabel.on('click', function(event) {
+    event.preventDefault();
+
+    var category = $(this).text();
+    filterInput.val(category).trigger('input');
+  });
+});

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -698,6 +698,7 @@ body > header > ul li a:hover {
 
 body > nav {
   top: 50px;
+  height: calc(100% - 50px);
 }
 
 #main {

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -23,6 +23,10 @@ img {
   max-width: 100%;
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 a,
 a:active {
   color: #606;
@@ -246,7 +250,7 @@ nav > h2 > a {
 
 footer {
   color: hsl(0, 0%, 28%);
-  margin-left: 250px;
+  margin-left: 290px;
   display: block;
   padding: 15px;
   font-style: italic;
@@ -318,12 +322,17 @@ footer {
 }
 
 .details pre.prettyprint {
-   margin: 0
+  margin: 0;
 }
 
-.details .tag-sig pre {
+.details .tag-sig {
   margin: 0
 }
+
+.details .tag-sig li {
+  margin-left: 80px;
+}
+
 
 .details .object-value {
    padding-top: 0
@@ -343,6 +352,7 @@ footer {
 .prettyprint {
   font-size: 14px;
   overflow: auto;
+  background-color: #000000;
 }
 
 .prettyprint.source {
@@ -415,7 +425,7 @@ footer {
 }
 
 .params .type {
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .params code {

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -13,7 +13,7 @@ body {
   color: #4d4e53;
   background-color: #F8F8F8;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 20px 0 0;
   font-family: 'Helvetica Neue', Helvetica, sans-serif;
   font-size: 16px;
   line-height: 160%;
@@ -134,7 +134,7 @@ tt, code, kbd, samp {
 #main {
   float: right;
   min-width: 360px;
-  width: calc(100% - 240px);
+  width: calc(100% - 270px);
 }
 
 header {
@@ -165,7 +165,7 @@ section {
 nav {
   float: left;
   display: block;
-  width: 260px;
+  width: 280px;
   background-color: #F8F8F8;
   overflow: auto;
   position: fixed;
@@ -180,7 +180,7 @@ nav h3 {
   font-weight: 700;
   line-height: 24px;
   margin: 15px 0 10px;
-  padding: 0;
+  padding: 0 0 0 20px;
   color: #000;
 }
 
@@ -207,7 +207,7 @@ nav a:active {
 }
 
 nav > ul {
-  padding: 0;
+  padding: 0 0 0 20px;
 }
 
 nav > ul > li > a {
@@ -733,12 +733,46 @@ body > header > ul li a:hover {
 }
 
 body > nav {
-  top: 50px;
-  height: calc(100% - 50px);
+  top: 100px;
+  padding-bottom: 10px;
+  height: calc(100% - 100px);
 }
 
 #main {
   margin-top: 50px;
+}
+
+#filter {
+  position: fixed;
+  top: 50px;
+  left: 0;
+  width: 280px;
+  height: 50px;
+  background-color: #F4F4F4;
+  border-bottom: 1px solid #CCCCCC;
+  border-right: 1px solid #CCCCCC;
+}
+
+#filter input {
+  width: 240px;
+  height: 30px;
+  line-height: 30px;
+  margin-left: 20px;
+  margin-top: 10px;
+  border: 1px solid #ccc;
+  font-size: 15px;
+  border-radius: 4px;
+  padding-left: 10px;
+}
+
+#filter input:focus {
+  outline: none !important;
+  border-color: #884499;
+  box-shadow: 0 0 3px #884499;
+}
+
+#filter input::placeholder {
+  color: #CCCCCC;
 }
 
 .section-id {

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -647,3 +647,61 @@ span.param-type, .params td .param-type, .param-type dd {
   margin-left: -14px;
   margin-right: 5px;
 }
+
+/** Custom extensions **/
+body > header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: block;
+  min-height: 50px;
+  margin-bottom: 20px;
+}
+
+body > header {
+  color: #fff;
+  background-color: #849;
+  box-shadow: 0 .25em .5em #d3d3d3;
+  border-bottom: 1px solid #d3d3d3;
+  margin: 0;
+  padding: .75em 10px .75em 40px;
+  z-index: 1000;
+}
+
+body > header a {
+  color: #e1d0e6;
+}
+
+body > header > ul {
+  float: right;
+  margin: 0;
+}
+
+body > header > ul li {
+  position: relative;
+  float: left;
+  display: block;
+}
+
+body > header > ul li a {
+  padding: 10px 15px;
+  font-size: 14px;
+}
+body > header > ul li a:hover {
+  color: #fff;
+}
+
+body > nav {
+  top: 50px;
+}
+
+#main {
+  margin-top: 50px;
+}
+
+.section-id {
+  height: 0;
+  position: relative;
+  top: -50px;
+}

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -317,7 +317,7 @@ footer {
    margin: 0
 }
 
-.detail .tag-sig pre {
+.details .tag-sig pre {
   margin: 0
 }
 

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -197,7 +197,6 @@ nav ul a,
 nav ul a:active {
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   line-height: 18px;
-  padding: 0;
   display: block;
   font-size: 14px;
 }
@@ -430,7 +429,7 @@ footer {
 }
 
 .params td, .params th, .props td, .props th {
-   margin: 0px;
+   margin: 0;
    text-align: left;
    vertical-align: top;
    padding: 10px;
@@ -677,14 +676,14 @@ span.param-type, .params td .param-type, .param-type dd {
 }
 
 [data-type="method"] {
-  padding-top: 7px;
-  padding-bottom: 7px;
   padding-right: 4px;
 }
 [data-type="method"]:hover {
   background-color: #e4e4e4 !important;
 }
 [data-type="method"] a {
+  padding-top: 7px;
+  padding-bottom: 7px;
   color: #ad6cbe;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -317,6 +317,10 @@ footer {
    margin: 0
 }
 
+.detail .tag-sig pre {
+  margin: 0
+}
+
 .details .object-value {
    padding-top: 0
 }

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -11,7 +11,7 @@ html, body {
 
 body {
   color: #4d4e53;
-  background-color: white;
+  background-color: #F8F8F8;
   margin: 0 auto;
   padding: 0 20px;
   font-family: 'Helvetica Neue', Helvetica, sans-serif;
@@ -62,8 +62,9 @@ h1 {
 }
 
 h1.page-title {
-  font-size: 48px;
+  /*font-size: 48px;*/
   margin: 1em 30px;
+  display: none;
 }
 
 h2 {
@@ -144,6 +145,10 @@ section {
   display: block;
   background-color: #fff;
   padding: 0 0 0 30px;
+  border: 1px solid #CCCCCC;
+  border-radius: 5px;
+  margin-left: 30px;
+  margin-top: 15px;
 }
 
 .variation {
@@ -160,15 +165,15 @@ section {
 nav {
   float: left;
   display: block;
-  width: 250px;
-  background: #fff;
+  width: 260px;
+  background-color: #F8F8F8;
   overflow: auto;
   position: fixed;
   height: 100%;
+  border-right: 1px solid #CCCCCC;
 }
 
 nav h3 {
-  margin-top: 12px;
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -190,11 +195,11 @@ nav ul {
 
 nav ul a,
 nav ul a:active {
-  font-family: 'Montserrat', sans-serif;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   line-height: 18px;
   padding: 0;
   display: block;
-  font-size: 12px;
+  font-size: 14px;
 }
 
 nav a:hover,
@@ -203,7 +208,7 @@ nav a:active {
 }
 
 nav > ul {
-  padding: 0 10px;
+  padding: 0;
 }
 
 nav > ul > li > a {
@@ -220,12 +225,12 @@ nav ul ul + ul {
 
 nav ul ul a {
   color: hsl(207, 1%, 60%);
-  border-left: 1px solid hsl(207, 10%, 86%);
+  /*border-left: 1px solid hsl(207, 10%, 86%);*/
 }
 
 nav ul ul a,
 nav ul ul a:active {
-  padding-left: 20px
+  padding-left: 9px;
 }
 
 nav h2 {
@@ -572,6 +577,25 @@ span.param-type, .params td .param-type, .param-type dd {
           transform: scale(0.75) rotate(45deg);
 }
 
+.label {
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+
+.label-category {
+  background: #e1d0e6;
+  color: #849;
+  float: right;
+}
+
 .nav-trigger:checked ~ nav {
   left: 0 !important;
 }
@@ -650,6 +674,19 @@ span.param-type, .params td .param-type, .param-type dd {
   display: inline-block;
   margin-left: -14px;
   margin-right: 5px;
+}
+
+[data-type="method"] {
+  padding-top: 7px;
+  padding-bottom: 7px;
+  padding-right: 4px;
+}
+[data-type="method"]:hover {
+  background-color: #e4e4e4 !important;
+}
+[data-type="method"] a {
+  color: #ad6cbe;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 /** Custom extensions **/

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -120,8 +120,22 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     <?js if (data.sig && sig.length) {?>
     <dt class="tag-sig">Signature:</dt>
     <dd class="tag-sig">
-        <ul><li><pre><code><?js= data.sig ?></code></pre></li></ul>
+        <ul>
+            <?js data.sig.forEach(function(sig) { ?>
+              <li><code><?js= sig ?></code></li>
+            <?js }) ?>
+        </ul>
     </dd>
+    <?js if (data.typedef && typedef.length) {?>
+        <dt class="tag-sig hidden">Signature:</dt>
+        <dd class="tag-sig">
+            <ul>
+                <?js data.typedef.forEach(function(typedef) { ?>
+                  <li><code><?js= typedef ?></code></li>
+                <?js }) ?>
+            </ul>
+        </dd>
+    <?js } ?>
     <?js } ?>
 
     <?js if (data.alias && alias.length) {?>

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -131,6 +131,13 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </dd>
     <?js } ?>
 
+    <?js if (data.aliases && aliases.length) {?>
+    <dt class="tag-category">Aliases:</dt>
+    <dd class="tag-category">
+        <ul><li><i><?js= data.aliases ?></i></li></ul>
+    </dd>
+    <?js } ?>
+
     <?js if (data.category && category.length) {?>
     <dt class="tag-category">Category:</dt>
     <dd class="tag-category">

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -124,6 +124,13 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </dd>
     <?js } ?>
 
+    <?js if (data.alias && alias.length) {?>
+    <dt class="tag-category">Aliases:</dt>
+    <dd class="tag-category">
+        <ul><li><i><?js= data.alias ?></i></li></ul>
+    </dd>
+    <?js } ?>
+
     <?js if (data.category && category.length) {?>
     <dt class="tag-category">Category:</dt>
     <dd class="tag-category">

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -132,7 +132,7 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     <?js } ?>
 
     <?js if (data.see && see.length) {?>
-    <dt class="tag-see">See:</dt>
+    <dt class="tag-see">See also:</dt>
     <dd class="tag-see">
         <ul><?js see.forEach(function(s) { ?>
             <li><?js= self.linkto(s) ?></li>

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -120,7 +120,7 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     <?js if (data.sig && sig.length) {?>
     <dt class="tag-sig">Signature:</dt>
     <dd class="tag-sig">
-        <ul><li><code><?js= data.sig ?></code></li></ul>
+        <ul><li><pre><code><?js= data.sig ?></code></pre></li></ul>
     </dd>
     <?js } ?>
 

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -117,15 +117,6 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </dd>
     <?js } ?>
 
-    <?js if (data.see && see.length) {?>
-    <dt class="tag-see">See:</dt>
-    <dd class="tag-see">
-        <ul><?js see.forEach(function(s) { ?>
-            <li><?js= self.linkto(s) ?></li>
-        <?js }); ?></ul>
-    </dd>
-    <?js } ?>
-
     <?js if (data.sig && sig.length) {?>
     <dt class="tag-sig">Signature:</dt>
     <dd class="tag-sig">
@@ -137,6 +128,15 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     <dt class="tag-category">Category:</dt>
     <dd class="tag-category">
         <ul><li><i><?js= data.category ?></i></li></ul>
+    </dd>
+    <?js } ?>
+
+    <?js if (data.see && see.length) {?>
+    <dt class="tag-see">See:</dt>
+    <dd class="tag-see">
+        <ul><?js see.forEach(function(s) { ?>
+            <li><?js= self.linkto(s) ?></li>
+            <?js }); ?></ul>
     </dd>
     <?js } ?>
 

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -126,6 +126,20 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
     </dd>
     <?js } ?>
 
+    <?js if (data.sig && sig.length) {?>
+    <dt class="tag-sig">Signature:</dt>
+    <dd class="tag-sig">
+        <ul><li><code><?js= data.sig ?></code></li></ul>
+    </dd>
+    <?js } ?>
+
+    <?js if (data.category && category.length) {?>
+    <dt class="tag-category">Category:</dt>
+    <dd class="tag-category">
+        <ul><li><i><?js= data.category ?></i></li></ul>
+    </dd>
+    <?js } ?>
+
     <?js if (data.todo && todo.length) {?>
     <dt class="tag-todo">To Do:</dt>
     <dd class="tag-todo">

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -21,6 +21,10 @@
 
 <label for="nav-trigger" class="overlay"></label>
 
+<header>
+    <?js= this.header ?>
+</header>
+
 <nav>
     <?js= this.nav ?>
 </nav>

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -6,6 +6,12 @@
 
     <script src="scripts/prettify/prettify.js"></script>
     <script src="scripts/prettify/lang-css.js"></script>
+    <script
+      src="https://code.jquery.com/jquery-3.2.1.min.js"
+      integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+      crossorigin="anonymous"
+    ></script>
+    <script src="scripts/search.js"></script>
     <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
@@ -26,6 +32,9 @@
 </header>
 
 <nav>
+    <div id="filter">
+        <input name="search" type="search" placeholder="Filter" />
+    </div>
     <?js= this.nav ?>
 </nav>
 

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -6,8 +6,8 @@ var self = this;
     <?js if (data.kind === 'class' && data.classdesc) { ?>
     <h2>Constructor</h2>
     <?js } ?>
-
-    <h4 class="name" id="<?js= id ?>"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
+    <div id="<?js= id ?>" class="section-id"></div>
+    <h4 class="name"><?js= data.attribs + (kind === 'class' ? 'new ' : '') +
     name + (data.signature || '') ?></h4>
 
     <?js if (data.summary) { ?>


### PR DESCRIPTION
I needed support for new tags @sig and @category to be able to generate ramda like docs.
Here is the source for jsdoc plugins:

```javascript
'use strict';

exports.defineTags = (dictionary) => {
  dictionary.defineTag('sig', {
    mustHaveValue: true,
    canHaveType: false,
    canHaveName: false,
    onTagged(doclet, tag) {
      doclet.sig = tag.value;
    },
  });

  dictionary.defineTag('category', {
    mustHaveValue: true,
    canHaveType: false,
    canHaveName: false,
    onTagged(doclet, tag) {
      doclet.category = tag.value;
    },
  });
};
```