### PR TITLE
Add viewport meta tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docdash",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A clean, responsive documentation template theme for JSDoc 3 inspired by lodash and minami",
   "main": "publish.js",
   "scripts": {

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -11,6 +11,7 @@
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 


### PR DESCRIPTION
Using the [`viewport` meta tag](https://developer.mozilla.org/en/docs/Mozilla/Mobile/Viewport_meta_tag) to allow smaller screen devices to take advantage of the awesome [responsiveness of the docdash theme](https://github.com/clenemt/docdash/blob/master/static/styles/jsdoc.css#L598)!

| Before | Zoom on mobile | After | ...with menu |
| ------ | ----------------- | ----- | ------------- |
| ![before](https://cloud.githubusercontent.com/assets/516342/25184734/f52b34a6-2523-11e7-868b-2b99840046c2.png) | ![zoom](https://cloud.githubusercontent.com/assets/516342/25886593/f5e7350e-3566-11e7-8e65-2e02aef395db.png) | ![after](https://cloud.githubusercontent.com/assets/516342/25184753/034d2b48-2524-11e7-8520-7b95c5378c5a.png) | ![after-menu](https://cloud.githubusercontent.com/assets/516342/25185065/e638aea0-2524-11e7-9269-5d80f1387d36.png) |

