### PR TITLE
Make use of mainpagetitle option

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -605,7 +605,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     var files = find({kind: 'file'});
     var packages = find({kind: 'package'});
 
-    generate('', 'Home',
+    generate('', opts.mainpagetitle || 'Home',
         packages.concat(
             [{kind: 'mainpage', readme: opts.readme, longname: (opts.mainpagetitle) ? opts.mainpagetitle : 'Main Page'}]
         ).concat(files),


### PR DESCRIPTION
currently, `opt.mainpagetitle` will not affect the site (nor would it on JSDOC's default template).
This makes it count, and makes the meta title fit as well (better for search engines)

(addresses https://github.com/jsdoc3/jsdoc/issues/1423)