### PR TITLE
Extend example code background color beyond the scroll box boundaries

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -335,6 +335,7 @@ footer {
 .prettyprint {
   font-size: 14px;
   overflow: auto;
+  background-color: #0d152a;
 }
 
 .prettyprint.source {
@@ -348,7 +349,7 @@ footer {
 .prettyprint code {
   line-height: 18px;
   display: block;
-  background-color: #0d152a;
+  background-color: transparent;
   color: #4D4E53;
 }
 


### PR DESCRIPTION
I've noticed that when there is a long line of `@example` code, the dark background only displays for the currently visible portion of the scroll box. One you start scrolling to the right, the background switches to a lighter color which makes the text hard to read. This small update will fix it.