### PR TITLE
Fix crash when @example is empty

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -448,14 +448,14 @@ exports.publish = function(taffyData, opts, tutorials) {
             doclet.examples = doclet.examples.map(function(example) {
                 var caption, code;
 
-                if (example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
+                if (example && example.match(/^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i)) {
                     caption = RegExp.$1;
                     code = RegExp.$3;
                 }
 
                 return {
                     caption: caption || '',
-                    code: code || example
+                    code: code || example || ''
                 };
             });
         }


### PR DESCRIPTION
Avoid a TypeError: Cannot read property 'match' of undefined in case where @example tag is empty