### PR TITLE
Fix - Use outputSourceFiles parameter from conf file

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -576,7 +576,7 @@ exports.publish = function(taffyData, opts, tutorials) {
     members.tutorials = tutorials.children;
 
     // output pretty-printed source files by default
-    var outputSourceFiles = conf.default && conf.default.outputSourceFiles !== false
+    var outputSourceFiles = conf.default && conf.outputSourceFiles !== false
         ? true
         : false;
 


### PR DESCRIPTION
 - Previously always equal to default (true) regardless of conf file so source code was always output/linked