### PR TITLE
Added support for @hidecontainer (jsdoc 3.5)

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -46,7 +46,7 @@ function needsSignature(doclet) {
     var needsSig = false;
 
     // function and class definitions always get a signature
-    if (doclet.kind === 'function' || doclet.kind === 'class') {
+    if (doclet.kind === 'function' || doclet.kind === 'class' && !doclet.hideconstructor) {
         needsSig = true;
     }
     // typedefs that contain functions get a signature, too
@@ -277,7 +277,7 @@ function attachModuleSymbols(doclets, modules) {
                 .map(function(symbol) {
                     symbol = doop(symbol);
 
-                    if (symbol.kind === 'class' || symbol.kind === 'function') {
+                    if (symbol.kind === 'class' || symbol.kind === 'function' && !symbol.hideconstructor) {
                         symbol.name = symbol.name.replace('module:', '(require("') + '"))';
                     }
 

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -41,30 +41,32 @@
 </header>
 
 <article>
-    <div class="container-overview">
-    <?js if (doc.kind === 'module' && doc.modules) { ?>
-        <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
-        <?js } ?>
+    <?js if (!doc.hideconstructor) { ?>
+        <div class="container-overview">
+        <?js if (doc.kind === 'module' && doc.modules) { ?>
+            <?js if (doc.description) { ?>
+                <div class="description"><?js= doc.description ?></div>
+            <?js } ?>
 
-        <?js doc.modules.forEach(function(module) { ?>
-            <?js= self.partial('method.tmpl', module) ?>
-        <?js }) ?>
-    <?js } else if (doc.kind === 'class') { ?>
-        <?js= self.partial('method.tmpl', doc) ?>
-    <?js } else { ?>
-        <?js= self.partial('details.tmpl', doc) ?>
+            <?js doc.modules.forEach(function(module) { ?>
+                <?js= self.partial('method.tmpl', module) ?>
+            <?js }) ?>
+        <?js } else if (doc.kind === 'class') { ?>
+            <?js= self.partial('method.tmpl', doc) ?>
+        <?js } else { ?>
+            <?js= self.partial('details.tmpl', doc) ?>
 
-        <?js if (doc.description) { ?>
-            <div class="description"><?js= doc.description ?></div>
-        <?js } ?>
+            <?js if (doc.description) { ?>
+                <div class="description"><?js= doc.description ?></div>
+            <?js } ?>
 
-        <?js if (doc.examples && doc.examples.length) { ?>
-            <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
-            <?js= self.partial('examples.tmpl', doc.examples) ?>
+            <?js if (doc.examples && doc.examples.length) { ?>
+                <h3>Example<?js= doc.examples.length > 1? 's':'' ?></h3>
+                <?js= self.partial('examples.tmpl', doc.examples) ?>
+            <?js } ?>
         <?js } ?>
+        </div>
     <?js } ?>
-    </div>
 
     <?js if (doc.augments && doc.augments.length) { ?>
         <h3 class="subsection-title">Extends</h3>

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -2,7 +2,7 @@
 var data = obj;
 var self = this;
 ?>
-<?js if (data.kind !== 'module') { ?>
+<?js if (data.kind !== 'module' && !data.hideconstructor) { ?>
     <?js if (data.kind === 'class' && data.classdesc) { ?>
     <h2>Constructor</h2>
     <?js } ?>


### PR DESCRIPTION
This hides the entire constructor block if `@hideconstructor` is specified on either the constructor or the class. jsDoc have had support for this annotation since version 3.5