### PR TITLE
Added hall-of-fame to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Docdash supports the following options:
 
 Place them anywhere inside your `jsdoc.json` file.
 
+## Contributors
+
+[![0](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/0)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/0)
+[![1](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/1)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/1)
+[![2](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/2)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/2)
+[![3](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/3)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/3)
+[![4](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/4)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/4)
+[![5](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/5)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/5)
+[![6](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/6)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/6)
+[![7](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/7)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/7)
+
 ## Thanks
 Thanks to [lodash](https://lodash.com) and [minami](https://github.com/nijikokun/minami).
 


### PR DESCRIPTION
As discussed with @ar2rsawseen by email.

Hall-of-fame is a widget that helps you recognize new/trending/top contributors in your repo. It is designed to be very visual, and change frequently. It autoupdates every hour and requires no maintenance.

Note that by accepting this PR, you will make me a contributor, which means my face will be featured as ’new’ on your Hall-of-fame for one week.

Also note that the widget uses @ar2rsawseen GitHub account to update stats, and makes 10-15 requests to GitHub API per hour (GitHub rate limit is 5,000 per hour).