### PR TITLE
Remove line-height: 160%

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -16,7 +16,6 @@ body {
   padding: 0 20px;
   font-family: 'Helvetica Neue', Helvetica, sans-serif;
   font-size: 16px;
-  line-height: 160%;
 }
 
 img {


### PR DESCRIPTION
Remove line-height: 160%,
It cause some overlapping problems especially on h1

See an example here : https://imgur.com/a/LvErnKN
