### PR TITLE
Add navLevel & private options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Docdash supports the following options:
         "search": [false|true],         // Display seach box above navigation which allows to search/filter navigation items
         "collapse": [false|true],       // Collapse navigation by default except current object's navigation of the current page
         "typedefs": [false|true],       // Include typedefs in menu
+        "navLevel": [integer],          // depth level to show in navbar, starting at 0
+        "private": [false|true],        // set to false to not show @private in navbar
         "removeQuotes": [none|all|trim],// Remove single and double quotes, trim removes only surrounding ones
         "scripts": []                   // Array of external (or relative local copied using templates.default.staticFiles.include) scripts to inject into HTML,
         "menu":{                        // Adding additional menu items after Home

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Docdash supports the following options:
         "search": [false|true],         // Display seach box above navigation which allows to search/filter navigation items
         "collapse": [false|true],       // Collapse navigation by default except current object's navigation of the current page
         "typedefs": [false|true],       // Include typedefs in menu
-        "navLevel": [integer],          // depth level to show in navbar, starting at 0
+        "navLevel": [integer],          // depth level to show in navbar, starting at 0 (false or -1 to disable)
         "private": [false|true],        // set to false to not show @private in navbar
         "removeQuotes": [none|all|trim],// Remove single and double quotes, trim removes only surrounding ones
         "scripts": []                   // Array of external (or relative local copied using templates.default.staticFiles.include) scripts to inject into HTML,

--- a/fixtures/fixtures.conf.json
+++ b/fixtures/fixtures.conf.json
@@ -26,7 +26,8 @@
         "monospaceLinks": false,
         "default": {
             "outputSourceFiles": true,
-            "includeDate": false
+            "includeDate": false,
+            "useLongnameInNav": true
         }
     },
     "docdash": {
@@ -47,6 +48,7 @@
 		},
         "search": true,
         "collapse": true,
+        "navLevel": 0,
         "typedefs": true,
         "removeQuotes": "none",
         "scripts": [],

--- a/publish.js
+++ b/publish.js
@@ -316,19 +316,23 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
 
     if (items && items.length) {
         var itemsNav = '';
+        var docdash = env && env.conf && env.conf.docdash || {};
+        var level = typeof docdash.navLevel === 'number' && docdash.navLevel >= 0 ?
+            docdash.navLevel :
+            Infinity;
 
         items.forEach(function(item) {
             var displayName;
             var methods = find({kind:'function', memberof: item.longname});
             var members = find({kind:'member', memberof: item.longname});
-            var docdash = env && env.conf && env.conf.docdash || {};
             var conf = env && env.conf || {};
             var classes = '';
 
             // show private class?
             if (docdash.private === false && item.access === 'private') return;
 
-            if (docdash.navLevel >= 0 && item.ancestors.length > docdash.navLevel) {
+            // depth to show?
+            if (item.ancestors.length > level) {
                 classes += 'level-hide';
             }
 
@@ -375,7 +379,6 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                     itemsNav += "</ul>";
                 }
 
-                itemsNav += '</li>';
                 itemsSeen[item.longname] = true;
             }
             itemsNav += '</li>';

--- a/publish.js
+++ b/publish.js
@@ -323,16 +323,26 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
             var members = find({kind:'member', memberof: item.longname});
             var docdash = env && env.conf && env.conf.docdash || {};
             var conf = env && env.conf || {};
+            var classes = '';
+
+            // show private class?
+            if (docdash.private === false && item.access === 'private') return;
+
+            if (docdash.navLevel >= 0 && item.ancestors.length > docdash.navLevel) {
+                classes += 'level-hide';
+            }
+
+            classes = classes ? ' class="'+ classes + '"' : '';
+            itemsNav +=  '<li'+ classes +'>';
             if ( !hasOwnProp.call(item, 'longname') ) {
-                itemsNav += '<li>' + linktoFn('', item.name);
-                itemsNav += '</li>';
+                itemsNav += linktoFn('', item.name);
             } else if ( !hasOwnProp.call(itemsSeen, item.longname) ) {
                 if (conf.templates.default.useLongnameInNav) {
                     displayName = item.longname;
                 } else {
                     displayName = item.name;
                 }
-                itemsNav += '<li>' + linktoFn(item.longname, displayName.replace(/\b(module|event):/g, ''));
+                itemsNav += linktoFn(item.longname, displayName.replace(/\b(module|event):/g, ''));
 
                 if (docdash.static && members.find(function (m) { return m.scope === 'static'; } )) {
                     itemsNav += "<ul class='members'>";
@@ -368,6 +378,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                 itemsNav += '</li>';
                 itemsSeen[item.longname] = true;
             }
+            itemsNav += '</li>';
         });
 
         if (itemsNav !== '') {

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -1,14 +1,17 @@
 $( document ).ready(function() {
+    var searchAttr = 'search-mode';
     jQuery.expr[':'].Contains = function(a,i,m){
         return (a.textContent || a.innerText || "").toUpperCase().indexOf(m[3].toUpperCase())>=0;
     };
     //on search
     $("#nav-search").on("keyup", function(event) {
         var search = $(this).val();
+
         if (!search) {
             //no search, show all results
-            $("nav > ul > li").show();
-            
+            document.documentElement.removeAttribute(searchAttr);
+            $("nav > ul > li").not('.level-hide').show();
+
             if(typeof hideAllButCurrent === "function"){
                 //let's do what ever collapse wants to do
                 hideAllButCurrent();
@@ -20,6 +23,8 @@ $( document ).ready(function() {
         }
         else{
             //we are searching
+            document.documentElement.setAttribute(searchAttr, '');
+
             //show all parents
             $("nav > ul > li").show();
             //hide all results

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -1,5 +1,5 @@
 $( document ).ready(function() {
-    var searchAttr = 'search-mode';
+    var searchAttr = 'data-search-mode';
     jQuery.expr[':'].Contains = function(a,i,m){
         return (a.textContent || a.innerText || "").toUpperCase().indexOf(m[3].toUpperCase())>=0;
     };

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -42,6 +42,7 @@ article a:hover, article a:active {
 
 p, ul, ol, blockquote {
   margin-bottom: 1em;
+  line-height: 160%;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -594,6 +595,15 @@ span.param-type, .params td .param-type, .param-type dd {
   background: hsla(0, 0%, 0%, 0.5);
   z-index: 1;
 }
+
+/* nav level */
+.level-hide {
+    display: none;
+}
+html[search-mode] .level-hide {
+    display: block;
+}
+
 
 @media only screen and (min-width: 320px) and (max-width: 680px) {
   body {

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -600,7 +600,7 @@ span.param-type, .params td .param-type, .param-type dd {
 .level-hide {
     display: none;
 }
-html[search-mode] .level-hide {
+html[data-search-mode] .level-hide {
     display: block;
 }
 


### PR DESCRIPTION
Motivation: for larger projects, the navbar quickly becomes too busy to be navigable.   Search is there, but the quick overview of a clean navbar is gone.

This PR adds a `navLevel` option to control the depth (as determined by ancestors) to show in the navbar. A value of `0` will show those classes that have no ancestor (i.e., root level), etc.

Also a `private: false` option will disable showing `@private` classes in the navbar.

Also, correction for #46 to re-instate line height for `<p>` and other tags.