### PR TITLE
Fix error when including tutorials

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -332,7 +332,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
             if (docdash.private === false && item.access === 'private') return;
 
             // depth to show?
-            if (item.ancestors.length > level) {
+            if (item.ancestors && item.ancestors.length > level) {
                 classes += 'level-hide';
             }
 


### PR DESCRIPTION
Adding check for existence of `ancestors` property on `item` before reading `ancestors.length`. The `ancestors` property does not exist on tutorial items so the build breaks with the following error:

```
C:\dev\projects\stuff\node_modules\docdash\publish.js:335
      if (item.ancestors.length > level) {
                         ^

TypeError: Cannot read property 'length' of undefined
```