### PR TITLE
Allow aliasing event names

### DIFF
--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -12,6 +12,8 @@ var self = this;
         print('new (require("' + name.slice(7) + '"))');
       } else if(kind === 'class') {
         print('new ' + name);
+      } else if(kind === 'event' && data.alias) {
+        print(data.alias);
       } else {
         print(name);
       }


### PR DESCRIPTION
This might be a corner case, but my team is using docdash and would like to be able to use @alias with @event.  We've made our event names available as constants on an object in the class, and would just like to alias them to display as `Event.FOO` instead of `Event:FOO` as that's how we expect our users to actually reference them.