### PR TITLE
 Add js to scroll nav so that the link to the current page is shown

### DIFF
--- a/static/scripts/collapse.js
+++ b/static/scripts/collapse.js
@@ -1,16 +1,14 @@
 function hideAllButCurrent(){
-    //by default all submenut items are hidden
-    document.querySelectorAll("nav > ul > li > ul li").forEach(function(parent) {
-        parent.style.display = "none";
-    });
-    
-    //only current page (if it exists) should be opened
-    var file = window.location.pathname.split("/").pop();
-    document.querySelectorAll("nav > ul > li > a[href^='"+file+"']").forEach(function(parent) {
+    // only current page (if it exists) should be opened
+    var file = window.location.pathname.split("/").pop().replace(/\.html/, '');
+    document.querySelectorAll("nav > ul > li > a").forEach(function(parent) {
+      var href = parent.attributes.href.value.replace(/\.html/, '');
+      if (file === href) {
         parent.parentNode.querySelectorAll("ul li").forEach(function(elem) {
-            elem.style.display = "block";
+          elem.style.display = "block";
         });
+      }
     });
-}
+  }
 
 hideAllButCurrent();

--- a/static/scripts/nav.js
+++ b/static/scripts/nav.js
@@ -1,0 +1,12 @@
+function scrollToNavItem() {
+    var path = window.location.href.split('/').pop().replace(/\.html/, '');
+    document.querySelectorAll('nav a').forEach(function(link) {
+      var href = link.attributes.href.value.replace(/\.html/, '');
+      if (path === href) {
+        link.scrollIntoView({block: 'center'});
+        return;
+      }
+    })
+  }
+
+  scrollToNavItem();

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -25,6 +25,7 @@
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc.css">
+    <script src="scripts/nav.js" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>


### PR DESCRIPTION
When the nav menu is long and you click a link towards the bottom, it's annoying that it scrolls back to the top on page load and the clicked link is no longer visible on the page.  This simply scrolls the nav link for the page currently being viewed is visible on page load.

It also contains a fix for the nav collapse script only matching on 'starts with', which in our project resulted in several items sometimes being opened.  For example we have a 'Session' class and a 'SessionManager' class, so 'starts with' Session matches both.  New logic matches exact name.  Let me know if this should be split out to a separate pull request.