### PR TITLE
Use the default font size by default

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -15,7 +15,6 @@ body {
   margin: 0 auto;
   padding: 0 20px;
   font-family: 'Helvetica Neue', Helvetica, sans-serif;
-  font-size: 16px;
 }
 
 img {
@@ -107,7 +106,6 @@ h4.name a:hover {
 }
 
 h5, .container-overview .subsection-title {
-  font-size: 120%;
   letter-spacing: -0.01em;
   margin: 8px 0 3px 0;
 }
@@ -126,7 +124,6 @@ tt, code, kbd, samp {
 }
 
 .class-description {
-  font-size: 130%;
   line-height: 140%;
   margin-bottom: 1em;
   margin-top: 1em;


### PR DESCRIPTION
Before this, fonts inside docdash where rendered
slightly larger than the average font on other sides.

In practiced this caused some of us to try do make the
font size smaller again since this would fit less information,
especially for smaller screen sizes (mobile devices).

This reverts to using the default font size for prosaic
text; this allows users to set the optimum font size for
their eyes & needs.