### PR TITLE
Hide static/private method depending of the config

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -375,6 +375,9 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                     itemsNav += "<ul class='methods'>";
 
                     methods.forEach(function (method) {
+                        if (docdash.static === false && method.scope === 'static') return;
+                        if (docdash.private === false && method.access === 'private') return;
+
                         itemsNav += "<li data-type='method'";
                         if(docdash.collapse)
                             itemsNav += " style='display: none;'";


### PR DESCRIPTION
Fix #71

Before : 

![image](https://user-images.githubusercontent.com/18501150/64683982-90b40800-d484-11e9-8a31-09e11af56b5a.png)

After : 

![image](https://user-images.githubusercontent.com/18501150/64687024-fc4ca400-d489-11e9-9d86-481615410a3d.png)

# Q/A : 

Set false `docdash.private` and check if you see private function (`@private`) in navigation menu.