### PR TITLE
Fix sementic `div > p` and `line-height` issue for description

### DIFF
--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -29,12 +29,12 @@
             <sup class="variation"><?js= doc.variation ?></sup>
         <?js } ?></h2>
         <?js if (doc.classdesc) { ?>
-            <div class="class-description"><?js= doc.classdesc ?></div>
+            <div class="class-description"><p><?js= doc.classdesc ?></p></div>
         <?js } ?>
     <?js } else if (doc.kind === 'module' && doc.modules) { ?>
         <?js doc.modules.forEach(function(module) { ?>
             <?js if (module.classdesc) { ?>
-                <div class="class-description"><?js= module.classdesc ?></div>
+                <div class="class-description"><p><?js= module.classdesc ?></p></div>
             <?js } ?>
         <?js }) ?>
     <?js } ?>
@@ -45,7 +45,7 @@
         <div class="container-overview">
         <?js if (doc.kind === 'module' && doc.modules) { ?>
             <?js if (doc.description) { ?>
-                <div class="description"><?js= doc.description ?></div>
+                <div class="description"><p><?js= doc.description ?></p></div>
             <?js } ?>
 
             <?js doc.modules.forEach(function(module) { ?>
@@ -57,7 +57,7 @@
             <?js= self.partial('details.tmpl', doc) ?>
 
             <?js if (doc.description) { ?>
-                <div class="description"><?js= doc.description ?></div>
+                <div class="description"><p><?js= doc.description ?></p></div>
             <?js } ?>
 
             <?js if (doc.examples && doc.examples.length) { ?>

--- a/tmpl/exceptions.tmpl
+++ b/tmpl/exceptions.tmpl
@@ -5,7 +5,7 @@
 <dl>
     <dt>
         <div class="param-desc">
-        <?js= data.description ?>
+            <p><?js= data.description ?></p>
         </div>
     </dt>
     <dd></dd>
@@ -23,10 +23,12 @@
 </dl>
 <?js } else { ?>
     <div class="param-desc">
-    <?js if (data.description) { ?>
-        <?js= data.description ?>
-    <?js } else if (data.type && data.type.names) { ?>
-        <?js= this.partial('type.tmpl', data.type.names) ?>
-    <?js } ?>
+        <p>
+        <?js if (data.description) { ?>
+            <?js= data.description ?>
+        <?js } else if (data.type && data.type.names) { ?>
+            <?js= this.partial('type.tmpl', data.type.names) ?>
+        <?js } ?>
+        </p>
     </div>
 <?js } ?>

--- a/tmpl/members.tmpl
+++ b/tmpl/members.tmpl
@@ -12,7 +12,7 @@ var self = this;
 
 <?js if (data.description) { ?>
 <div class="description">
-    <?js= data.description ?>
+    <p><?js= data.description ?></p>
 </div>
 <?js } ?>
 

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -28,7 +28,7 @@ var self = this;
 
 <?js if (data.kind !== 'module' && data.description) { ?>
 <div class="description">
-    <?js= data.description ?>
+    <p><?js= data.description ?></p>
 </div>
 <?js } ?>
 

--- a/tmpl/returns.tmpl
+++ b/tmpl/returns.tmpl
@@ -3,7 +3,7 @@ var data = obj || {};
 if (data.description) {
 ?>
 <div class="param-desc">
-    <?js= description ?>
+    <p><?js= description ?></p>
 </div>
 <?js } ?>
 


### PR DESCRIPTION
`line-height` only apply on `p, ul, ol, blockquote`, not `div`, see : 

https://github.com/clenemt/docdash/blob/5e99ca0bb36dc3535ac3803782c4275c97768552/static/styles/jsdoc.css#L45-L48

Sementic, according to: https://stackoverflow.com/a/2226574/2226755 elements should be : `div > p > {nodeText}` 

Before: 
![image](https://user-images.githubusercontent.com/18501150/64689942-97944800-d48f-11e9-9383-1851c32d20fd.png)

After: 
![image](https://user-images.githubusercontent.com/18501150/64689910-89462c00-d48f-11e9-8697-70552e8b73a9.png)

# Q/A

Check the line-height in the documentation