### PR TITLE
Added possibility to exclude package scope/name and version from output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,10 @@ Docdash supports the following options:
                 "class":"menu-item",
                 "id":"forum_link"
             }
-        }
+        },
+        scopeInOutputPath: [false|true], // Add scope from package file (if present) to the output path, true by default.
+        nameInOutputPath: [false|true], // Add name from package file to the output path, true by default.
+        versionInOutputPath: [false|true] // Add package version to the output path, true by default. 
     }
 }
 ```

--- a/publish.js
+++ b/publish.js
@@ -579,9 +579,30 @@ exports.publish = function(taffyData, opts, tutorials) {
 
     // update outdir if necessary, then create outdir
     var packageInfo = ( find({kind: 'package'}) || [] ) [0];
-    if (packageInfo && packageInfo.name) {
-        outdir = path.join( outdir, packageInfo.name, (packageInfo.version || '') );
+    if (packageInfo) {
+        var subdirs = [outdir];
+
+        if (packageInfo.name) {
+            var packageName = packageInfo.name.split('/');
+
+            if (packageName.length > 1 && docdash.scopeInOutputPath !== false) {
+                subdirs.push(packageName[0]);
+            }
+
+            if (docdash.nameInOutputPath !== false) {
+                subdirs.push((packageName.length > 1 ? packageName[1] : packageName[0]));
+            }
+        }
+
+        if (packageInfo.version && docdash.versionInoutputPath !== false) {
+            subdirs.push(packageInfo.version);
+        }
+
+        if (subdirs.length > 1) {
+            outdir = path.join.apply(null, subdirs);
+        }
     }
+    
     fs.mkPath(outdir);
 
     // copy the template's static files to outdir

--- a/publish.js
+++ b/publish.js
@@ -594,7 +594,7 @@ exports.publish = function(taffyData, opts, tutorials) {
             }
         }
 
-        if (packageInfo.version && docdash.versionInoutputPath !== false) {
+        if (packageInfo.version && docdash.versionInOutputPath !== false) {
             subdirs.push(packageInfo.version);
         }
 


### PR DESCRIPTION
Current behavior: If package.json is specified in jdoc options, library name and version are added to the output path so generated output path becomes `out/<name>/<version>` or `out/<scope>/<name>/<version>` if library is scoped. In most cases this is unnesessary.

Modified behavior: including scope, name and version is controlled by options. If these options haven't been set explicitly, old behavior is used, so this is not breaking change.