### PR TITLE
Fix regular expression in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See the config file for the [fixtures](fixtures/fixtures.conf.json) or the sampl
     },
     "source": {
         "include": "../js",
-        "includePattern": ".js$",
+        "includePattern": "\\.js$",
         "excludePattern": "(node_modules/|docs)"
     },
     "plugins": [


### PR DESCRIPTION
Escape the "." character in the file extension.