### PR TITLE
Adjusted layout for namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/clenemt/docdash.git"
+    "url": "https://github.com/edgar-koster/docdash"
   },
   "devDependencies": {
     "jsdoc": "latest",
     "browser-sync": "latest",
     "watch-run": "latest"
   },
-  "author": "Clement Moron <clement.moron@gmail.com>",
   "license": "Apache-2.0",
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/edgar-koster/docdash"
+    "url": "https://github.com/clenemt/docdash.git"
   },
   "devDependencies": {
     "jsdoc": "latest",
     "browser-sync": "latest",
     "watch-run": "latest"
   },
+  "author": "Clement Moron <clement.moron@gmail.com>",
   "license": "Apache-2.0",
   "keywords": [
     "jsdoc",

--- a/publish.js
+++ b/publish.js
@@ -378,12 +378,20 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                         if (docdash.static === false && method.scope === 'static') return;
                         if (docdash.private === false && method.access === 'private') return;
 
-                        itemsNav += "<li data-type='method'";
+                        var navItem = '';
+                        var navItemLink = linkto(method.longname, method.name);
+                        var strNewLink = '.html#' + method.name;
+
+                        navItemLink = navItemLink.replace('.html', strNewLink);
+
+                        navItem += "<li data-type='method'";
                         if(docdash.collapse)
-                            itemsNav += " style='display: none;'";
-                        itemsNav += ">";
-                        itemsNav += linkto(method.longname, method.name);
-                        itemsNav += "</li>";
+                            navItem += " style='display: none;'";
+                        navItem += ">";
+                        navItem += navItemLink;
+                        navItem += "</li>";
+
+                        itemsNav += navItem;
                     });
 
                     itemsNav += "</ul>";

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -20,7 +20,7 @@
 <section>
 
 <header>
-    <?js if (!doc.longname || doc.kind !== 'module') { ?>
+    <?js if ((!doc.longname || doc.kind !== 'module') && doc.kind !== 'namespace') { ?>
         <h2><?js if (doc.ancestors && doc.ancestors.length) { ?>
             <span class="ancestors"><?js= doc.ancestors.join('') ?></span>
         <?js } ?>
@@ -31,7 +31,7 @@
         <?js if (doc.classdesc) { ?>
             <div class="class-description usertext"><?js= doc.classdesc ?></div>
         <?js } ?>
-    <?js } else if (doc.kind === 'module' && doc.modules) { ?>
+    <?js } else if (doc.kind === 'module' && doc.modules && doc.kind !== 'namespace') { ?>
         <?js doc.modules.forEach(function(module) { ?>
             <?js if (module.classdesc) { ?>
                 <div class="class-description"><?js= module.classdesc ?></div>
@@ -53,6 +53,8 @@
             <?js }) ?>
         <?js } else if (doc.kind === 'class') { ?>
             <?js= self.partial('method.tmpl', doc) ?>
+        <?js } else if (doc.kind === 'namespace') { ?>
+            <?js= self.partial('namespace.tmpl', doc) ?>
         <?js } else { ?>
             <?js= self.partial('details.tmpl', doc) ?>
 

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -24,7 +24,11 @@
         <h2><?js if (doc.ancestors && doc.ancestors.length) { ?>
             <span class="ancestors"><?js= doc.ancestors.join('') ?></span>
         <?js } ?>
-        <?js= doc.name ?>
+        <?js if (doc.kind === 'namespace') { ?>
+            Namespace
+        <?js } else { ?>
+            <?js= doc.name ?>
+        <?js } ?>
         <?js if (doc.variation) { ?>
             <sup class="variation"><?js= doc.variation ?></sup>
         <?js } ?></h2>

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -20,7 +20,7 @@
 <section>
 
 <header>
-    <?js if ((!doc.longname || doc.kind !== 'module') && doc.kind !== 'namespace') { ?>
+    <?js if (!doc.longname || doc.kind !== 'module') { ?>
         <h2><?js if (doc.ancestors && doc.ancestors.length) { ?>
             <span class="ancestors"><?js= doc.ancestors.join('') ?></span>
         <?js } ?>
@@ -31,7 +31,7 @@
         <?js if (doc.classdesc) { ?>
             <div class="class-description usertext"><?js= doc.classdesc ?></div>
         <?js } ?>
-    <?js } else if (doc.kind === 'module' && doc.modules && doc.kind !== 'namespace') { ?>
+    <?js } else if (doc.kind === 'module' && doc.modules && doc.kind) { ?>
         <?js doc.modules.forEach(function(module) { ?>
             <?js if (module.classdesc) { ?>
                 <div class="class-description"><?js= module.classdesc ?></div>

--- a/tmpl/container.tmpl
+++ b/tmpl/container.tmpl
@@ -35,7 +35,7 @@
         <?js if (doc.classdesc) { ?>
             <div class="class-description usertext"><?js= doc.classdesc ?></div>
         <?js } ?>
-    <?js } else if (doc.kind === 'module' && doc.modules && doc.kind) { ?>
+    <?js } else if (doc.kind === 'module' && doc.modules) { ?>
         <?js doc.modules.forEach(function(module) { ?>
             <?js if (module.classdesc) { ?>
                 <div class="class-description"><?js= module.classdesc ?></div>

--- a/tmpl/details.tmpl
+++ b/tmpl/details.tmpl
@@ -15,6 +15,10 @@ if (data.defaultvalue && (data.defaultvaluetype === 'object' || data.defaultvalu
 ?>
 
 <dl class="details">
+    <?js if (data.description) {?>
+    <dt class="tag-description">Description:</dt>
+    <dd class="tag-description"><ul class="dummy"><li><?js= data.description ?></li></ul></dd>
+    <?js } ?>
 
     <?js if (data.meta && self.outputSourceFiles) {?>
     <dt class="tag-source">Source:</dt>

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -26,12 +26,6 @@ var self = this;
 
 <?js= this.partial('details.tmpl', data) ?>
 
-<?js if (data.kind !== 'module' && data.description) { ?>
-<div class="description usertext">
-    <?js= data.description ?>
-</div>
-<?js } ?>
-
 <?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
     <h5>Extends:</h5>
     <?js= self.partial('augments.tmpl', data) ?>

--- a/tmpl/namespace.tmpl
+++ b/tmpl/namespace.tmpl
@@ -1,0 +1,117 @@
+<?js
+var data = obj;
+var self = this;
+?>
+
+<?js if (data.kind !== 'module' && data.description) { ?>
+<div class="description usertext">
+    <?js= data.description ?>
+</div>
+<?js } ?>
+
+<?js= this.partial('details.tmpl', data) ?>
+
+<?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
+    <h5>Extends:</h5>
+    <?js= self.partial('augments.tmpl', data) ?>
+<?js } ?>
+
+<?js if (kind === 'event' && data.type && data.type.names) {?>
+    <h5>Type:</h5>
+    <ul>
+        <li>
+            <?js= self.partial('type.tmpl', data.type.names) ?>
+        </li>
+    </ul>
+<?js } ?>
+
+<?js if (data['this']) { ?>
+    <h5>This:</h5>
+    <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
+<?js } ?>
+
+<?js if (data.examples && examples.length) { ?>
+    <h5>Example<?js= examples.length > 1? 's':'' ?></h5>
+    <?js= this.partial('examples.tmpl', examples) ?>
+<?js } ?>
+
+<?js if (data.params && params.length) { ?>
+    <h5>Parameters:</h5>
+    <?js= this.partial('params.tmpl', params) ?>
+<?js } ?>
+
+<?js if (data.kind !== 'module' && data.requires && data.requires.length) { ?>
+<h5>Requires:</h5>
+<ul><?js data.requires.forEach(function(r) { ?>
+    <li><?js= self.linkto(r) ?></li>
+<?js }); ?></ul>
+<?js } ?>
+
+<?js if (data.fires && fires.length) { ?>
+<h5>Fires:</h5>
+<ul><?js fires.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
+
+<?js if (data.listens && listens.length) { ?>
+<h5>Listens to Events:</h5>
+<ul><?js listens.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
+
+<?js if (data.listeners && listeners.length) { ?>
+<h5>Listeners of This Event:</h5>
+<ul><?js listeners.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
+
+<?js if (data.modifies && modifies.length) {?>		
+<h5>Modifies:</h5>		
+<?js if (modifies.length > 1) { ?><ul><?js		
+    modifies.forEach(function(m) { ?>		
+        <li><?js= self.partial('modifies.tmpl', m) ?></li>		
+    <?js });		
+?></ul><?js } else {		
+    modifies.forEach(function(m) { ?>		
+        <?js= self.partial('modifies.tmpl', m) ?>		
+    <?js });		
+} } ?>
+
+<?js if (data.exceptions && exceptions.length) { ?>
+<h5>Throws:</h5>
+<?js if (exceptions.length > 1) { ?><ul><?js
+    exceptions.forEach(function(r) { ?>
+        <li><?js= self.partial('exceptions.tmpl', r) ?></li>
+    <?js });
+?></ul><?js } else {
+    exceptions.forEach(function(r) { ?>
+        <?js= self.partial('exceptions.tmpl', r) ?>
+    <?js });
+} } ?>
+
+<?js if (data.returns && returns.length) { ?>
+<h5>Returns:</h5>
+<?js if (returns.length > 1) { ?><ul><?js
+    returns.forEach(function(r) { ?>
+        <li><?js= self.partial('returns.tmpl', r) ?></li>
+    <?js });
+?></ul><?js } else {
+    returns.forEach(function(r) { ?>
+        <?js= self.partial('returns.tmpl', r) ?>
+    <?js });
+} } ?>
+
+<?js if (data.yields && yields.length) { ?>		
+<h5>Yields:</h5>		
+<?js if (yields.length > 1) { ?><ul><?js		
+    yields.forEach(function(r) { ?>		
+        <li><?js= self.partial('returns.tmpl', r) ?></li>		
+    <?js });		
+?></ul><?js } else {		
+    yields.forEach(function(r) { ?>		
+        <?js= self.partial('returns.tmpl', r) ?>		
+    <?js });		
+} } ?>

--- a/tmpl/namespace.tmpl
+++ b/tmpl/namespace.tmpl
@@ -3,10 +3,26 @@ var data = obj;
 var self = this;
 ?>
 
-<?js if (data.kind !== 'module' && data.description) { ?>
-<div class="description usertext">
-    <?js= data.description ?>
-</div>
+<?js if (data.kind !== 'module' && !data.hideconstructor) { ?>
+    <?js if (data.kind === 'class' && data.classdesc) { ?>
+    <h2>Constructor</h2>
+    <?js } ?>
+
+    <h4 class="name" id="<?js= id ?>"><?js= data.attribs ?><?js
+      if(kind === 'class' && name.indexOf('module:') === 0) {
+        print('new (require("' + name.slice(7) + '"))');
+      } else if(kind === 'class') {
+        print('new ' + name);
+      } else if(kind === 'event' && data.alias) {
+        print(data.alias);
+      } else {
+        print(name);
+      }
+    ?><?js= (data.signature || '') ?></h4>
+
+    <?js if (data.summary) { ?>
+    <p class="summary usertext"><?js= summary ?></p>
+    <?js } ?>
 <?js } ?>
 
 <?js= this.partial('details.tmpl', data) ?>


### PR DESCRIPTION
For issue #85 I made some changes to the code. This is the first step. I think it's better to have the description at the top otherwise you first need to scroll to read what the namespace is about. It now looks like this (I admit I might misuse namespace for a object definition, but the idea is the still the same)

Code changes for the request:
container.tmpl => add conditions for namespace
namespace.tml => new file for the display

At the same time, I moved the description to be included in the structure where since, author, version also resides. These changes are in:
method.tmp => remove the description section
details.tmp => add the description condition

![image](https://user-images.githubusercontent.com/24190040/90290202-b52b1800-de7d-11ea-997c-ebf4c4fd394e.png)
