### PR TITLE
add a commonNav option to set nav html code in one file only

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Docdash supports the following options:
             "keyword": ""               // Keywords for search engines
         },
         "search": [false|true],         // Display seach box above navigation which allows to search/filter navigation items
+        "commonNav": [false|true],      // Group all html code for <nav> in a nav.inc.html fetched on each page (instead of include it in each html page, save {navSize}×{nb html pages} which can be huge on big project)
         "collapse": [false|true],       // Collapse navigation by default except current object's navigation of the current page
         "wrap": [false|true],           // Wrap long navigation names instead of trimming them
         "typedefs": [false|true],       // Include typedefs in menu

--- a/publish.js
+++ b/publish.js
@@ -730,6 +730,11 @@ exports.publish = function(taffyData, opts, tutorials) {
         ).concat(files),
     indexUrl);
 
+    // common nav generation, no need for templating here, we already have full html
+    if (docdash.commonNav) {
+        fs.writeFileSync(path.join(outdir, 'nav.inc.html'), view.nav, 'utf8');
+    }
+
     // set up the lists that we'll use to generate pages
     var classes = taffy(members.classes);
     var modules = taffy(members.modules);

--- a/static/scripts/commonNav.js
+++ b/static/scripts/commonNav.js
@@ -1,0 +1,29 @@
+if (typeof fetch === 'function') {
+  const init = () => {
+    if (typeof scrollToNavItem !== 'function') return false
+    scrollToNavItem()
+    // hideAllButCurrent not always loaded
+    if (typeof hideAllButCurrent === 'function') hideAllButCurrent()
+    else console.log('hideAllButCurrent not exists')
+    return true
+  }
+  fetch('./nav.inc.html')
+    .then(response => response.ok ? response.text() : `${response.url} => ${response.status} ${response.statusText}`)
+    .then(body => {
+      document.querySelector('nav').innerHTML += body
+      // nav.js should be quicker to load than nav.inc.html, a fallback just in case
+      return init()
+    })
+    .then(done => {
+      if (done) return
+      let i = 0
+      ;(function waitUntilNavJs () {
+        if (init()) return
+        if (i++ < 100) return setTimeout(waitUntilNavJs, 300)
+        console.error(Error('nav.js not loaded after 30s waiting for it'))
+      })()
+    })
+    .catch(error => console.error(error))
+} else {
+  console.error(Error('Browser too old to display commonNav (remove commonNav docdash option)'))
+}

--- a/static/scripts/commonNav.js
+++ b/static/scripts/commonNav.js
@@ -4,7 +4,6 @@ if (typeof fetch === 'function') {
     scrollToNavItem()
     // hideAllButCurrent not always loaded
     if (typeof hideAllButCurrent === 'function') hideAllButCurrent()
-    else console.log('hideAllButCurrent not exists')
     return true
   }
   fetch('./nav.inc.html')

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -26,6 +26,9 @@
     <link type="text/css" rel="stylesheet" href="styles/prettify.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc.css">
     <script src="scripts/nav.js" defer></script>
+    <?js if (env.conf.docdash.commonNav) { ?>
+    <script src="scripts/commonNav.js" defer></script>
+    <?js } ?>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
@@ -41,7 +44,9 @@
     <?js if (env.conf.docdash.search) { ?>
     <input type="text" id="nav-search" placeholder="Search" />
     <?js } ?>
+    <?js if (!env.conf.docdash.commonNav) { ?>
     <?js= this.nav ?>
+    <?js } ?>
 </nav>
 
 <div id="main">


### PR DESCRIPTION
The nav html code is fetched after each page loading (instead of being embedded), in my case total doc weight get reduced from 2.3Go to 40Mo (2Mo for nav.inc.html, 600k html pages).

Close #75 