### PR TITLE
Added double quotes to README for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Docdash supports the following options:
                 "id":"forum_link"
             }
         },
-        scopeInOutputPath: [false|true], // Add scope from package file (if present) to the output path, true by default.
-        nameInOutputPath: [false|true], // Add name from package file to the output path, true by default.
-        versionInOutputPath: [false|true] // Add package version to the output path, true by default. 
+        "scopeInOutputPath": [false|true], // Add scope from package file (if present) to the output path, true by default.
+        "nameInOutputPath": [false|true], // Add name from package file to the output path, true by default.
+        "versionInOutputPath": [false|true] // Add package version to the output path, true by default. 
     }
 }
 ```


### PR DESCRIPTION
Even though this feature hasn't been released yet, I figured you wouldn't mind some fixes to the consistency in the config file example since there have been typo fixes in the past.