### PR TITLE
Fix extra scroll bar on large code blocks

### DIFF
--- a/static/styles/prettify.css
+++ b/static/styles/prettify.css
@@ -76,4 +76,5 @@
 ol.linenums {
   margin-top: 0;
   margin-bottom: 0;
+  padding-bottom: 2px;
 }


### PR DESCRIPTION
When viewing the source of a file and the line numbers are visible in the code block, a second vertical scrollbar appears in the `<pre>` element. Adding a 2px bottom padding to the `ol.linenums` element fixes this issue.

Before:
![image](https://user-images.githubusercontent.com/1304204/116824046-0c7d2f80-ab56-11eb-93d6-1a6df1d4dadd.png)

After:
![image](https://user-images.githubusercontent.com/1304204/116824049-13a43d80-ab56-11eb-9fca-3ed52de2c637.png)

