### PR TITLE
Update CSS for <pre>

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -162,9 +162,12 @@ h6 {
 }
 
 
-tt, code, kbd, samp {
+tt, code, kbd, samp, pre {
   font-family: Consolas, Monaco, 'Andale Mono', monospace;
   background: #f4f4f4;
+}
+
+tt, code, kbd, samp{
   padding: 1px 5px;
 }
 

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -171,6 +171,10 @@ tt, code, kbd, samp{
   padding: 1px 5px;
 }
 
+pre {
+  padding-bottom: 1em;
+}  
+
 .class-description {
   font-size: 130%;
   line-height: 140%;


### PR DESCRIPTION
closes https://github.com/clenemt/docdash/issues/102

This updated CSS changes this:

> ![image](https://user-images.githubusercontent.com/177243/138120981-7cd63a0c-d91e-4e03-acd5-335b0914e154.png)

Into this:

> ![image](https://user-images.githubusercontent.com/177243/138123290-6bd16be4-2bb2-4318-9f68-65917a4f0535.png)

