### PR TITLE
Feature/shorten types

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Docdash supports the following options:
         "private": [false|true],        // set to false to not show @private in navbar
         "removeQuotes": [none|all|trim],// Remove single and double quotes, trim removes only surrounding ones
         "scripts": [],                  // Array of external (or relative local copied using templates.default.staticFiles.include) js or css files to inject into HTML,
+        "ShortenTypes": [false|true], // If set to true this will resolve the display name of all types as the shortened name only (after the final period).
         "menu": {                       // Adding additional menu items after Home
             "Project Website": {        // Menu item name
                 "href":"https://myproject.com", //the rest of HTML properties to add to manu item

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -1,7 +1,14 @@
 <?js
     var data = obj;
     var self = this;
-    data.forEach(function(name, i) { ?>
-<span class="param-type"><?js= self.linkto(name, self.htmlsafe(name)) ?></span>
+    data.forEach(function(name, i) {
+    if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
+        var nameArr = name.split(".");
+        var resolvedName = nameArr[nameArr.length - 1];
+    } else {
+        var resolvedName = name;
+    }
+    ?>
+<span class="param-type"><?js= self.linkto(name, self.htmlsafe(resolvedName))?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -5,10 +5,18 @@
     if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
         var nameArr = name.split(/[\.~#]/);
         var resolvedName = nameArr[nameArr.length - 1];
+        if (name.startsWith("Array.<")) {
+                    resolvedName = resolvedName.replace(">", "");
+                    var longname = name.replace("Array.<","").replace(">", "");
+        }
     } else {
         var resolvedName = name;
     }
+    var link = self.linkto(name, self.htmlsafe(resolvedName));
+    if (longname) {
+        link = link.replace(longname, resolvedName);
+    }
     ?>
-<span class="param-type"><?js= self.linkto(name, self.htmlsafe(resolvedName))?></span>
+<span class="param-type"><?js= link + " " + self.htmlsafe(longname)?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -6,8 +6,12 @@
         var nameArr = name.split(/[\.~#]/);
         var resolvedName = nameArr[nameArr.length - 1];
         if (name.startsWith("Array.<")) {
-                    resolvedName = resolvedName.replace(">", "");
-                    var longname = name.replace("Array.<","").replace(">", "");
+            if (nameArr.length === 2) {
+                resolvedName = name;
+            } else {
+                resolvedName = resolvedName.replace(">", "");
+                var longname = name.replace("Array.<","").replace(">", "");
+            }
         }
     } else {
         var resolvedName = name;

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -3,7 +3,7 @@
     var self = this;
     data.forEach(function(name, i) {
     if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
-        var nameArr = name.split(".");
+        var nameArr = name.split(/[\.~#]/);
         var resolvedName = nameArr[nameArr.length - 1];
     } else {
         var resolvedName = name;

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -17,6 +17,6 @@
         link = link.replace(longname, resolvedName);
     }
     ?>
-<span class="param-type"><?js= link + " " + self.htmlsafe(longname)?></span>
+<span class="param-type"><?js= link?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>


### PR DESCRIPTION
This is a small edit, but makes me happy so I figured I would propose it. I wanted an option to take a long type name (e.g. foo.bar, foo~bar or foo#bar) and truncate it to just the shortened name of the type for the link's name itself (e.g. bar). I made this opt-in only by adding it as a config option in the docdash object and already updated the readme to add the added option to the documentation for docdash options. 

Currently tested against my repo where I was using namespaces to group different items and found it annoying that this added the extra namespaces to every declaration in my docs. 