### PR TITLE
Applied fix for navigation links to work with jsdoc latest linkto method

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -380,9 +380,15 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
 
                         var navItem = '';
                         var navItemLink = linkto(method.longname, method.name);
-                        var strNewLink = '.html#' + method.name;
 
-                        navItemLink = navItemLink.replace('.html', strNewLink);
+                        // Not certain if there is a situation where this is needed anymore
+                        // linkto method seems to solve this problem already, but at least this check
+                        // will prevent duplicate #'s in links.
+                        if (!navItemLink.includes("#." + method.name)) {
+                            var strNewLink = '.html#.' + method.name;
+
+                            navItemLink = navItemLink.replace(".html", strNewLink);
+                        }
 
                         navItem += "<li data-type='method'";
                         if(docdash.collapse)


### PR DESCRIPTION
I noticed that links started having errors when using the latest github commit. Every link ended up with two #'s at the end (e.g. .html#foo#.foo) I tracked it back to commit 70c2cfadbcffef313c67b12a6656855d0d47b67c which seems to be based off of the links not including this jump to originally. I added a check for if the jump to # was already in the html to prevent breaking the links when updating to the new jsdoc utils which include these in the url already. Leaving in the check so it will work either way for now. 