### PR TITLE
Feature/typedef in member nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Docdash supports the following options:
         "private": [false|true],        // set to false to not show @private in navbar
         "removeQuotes": [none|all|trim],// Remove single and double quotes, trim removes only surrounding ones
         "scripts": [],                  // Array of external (or relative local copied using templates.default.staticFiles.include) js or css files to inject into HTML,
+        "ShortenTypes": [false|true], // If set to true this will resolve the display name of all types as the shortened name only (after the final period).
         "menu": {                       // Adding additional menu items after Home
             "Project Website": {        // Menu item name
                 "href":"https://myproject.com", //the rest of HTML properties to add to manu item

--- a/publish.js
+++ b/publish.js
@@ -332,6 +332,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
             var displayName;
             var methods = find({kind:'function', memberof: item.longname});
             var members = find({kind:'member', memberof: item.longname});
+            var typedefs = find({kind:'typedef', memberof: item.longname});
             var conf = env && env.conf || {};
             var classes = '';
 
@@ -398,6 +399,22 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                         navItem += "</li>";
 
                         itemsNav += navItem;
+                    });
+
+                    itemsNav += "</ul>";
+                }
+
+                if (docdash.typedefs && typedefs.find(function (m) { return m.scope === 'static'; } )) {
+                    itemsNav += "<ul class='typedefs'>";
+
+                    typedefs.forEach(function (typedef) {
+                        if (!typedef.scope === 'static') return;
+                        itemsNav += "<li data-type='typedef'";
+                        if(docdash.collapse)
+                            itemsNav += " style='display: none;'";
+                        itemsNav += ">";
+                        itemsNav += linkto(typedef.longname, typedef.name);
+                        itemsNav += "</li>";
                     });
 
                     itemsNav += "</ul>";
@@ -475,7 +492,7 @@ function buildNav(members) {
 
         members.globals.forEach(function(g) {
             if ( (docdash.typedefs || g.kind !== 'typedef') && !hasOwnProp.call(seen, g.longname) ) {
-                globalNav += '<li>' + linkto(g.longname, g.name) + '</li>';
+                globalNav += '<li data-type="typedef">' + linkto(g.longname, g.name) + '</li>';
             }
             seen[g.longname] = true;
         });

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -713,6 +713,17 @@ html[data-search-mode] .level-hide {
   margin-right: 5px;
 }
 
+/** Add a '●' to typedef static members */
+[data-type="typedef"] a::before {
+  content: '\25CF';
+  font-size: .55rem;
+  position: relative;
+  top: -2px;
+  display: inline-block;
+  margin-left: -14px;
+  margin-right: 5px;
+}
+
 #disqus_thread{
     margin-left: 30px;
 }

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -1,7 +1,14 @@
 <?js
     var data = obj;
     var self = this;
-    data.forEach(function(name, i) { ?>
-<span class="param-type"><?js= self.linkto(name, self.htmlsafe(name)) ?></span>
+    data.forEach(function(name, i) {
+    if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
+        var nameArr = name.split(".");
+        var resolvedName = nameArr[nameArr.length - 1];
+    } else {
+        var resolvedName = name;
+    }
+    ?>
+<span class="param-type"><?js= self.linkto(name, self.htmlsafe(resolvedName))?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -5,10 +5,18 @@
     if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
         var nameArr = name.split(/[\.~#]/);
         var resolvedName = nameArr[nameArr.length - 1];
+        if (name.startsWith("Array.<")) {
+                    resolvedName = resolvedName.replace(">", "");
+                    var longname = name.replace("Array.<","").replace(">", "");
+        }
     } else {
         var resolvedName = name;
     }
+    var link = self.linkto(name, self.htmlsafe(resolvedName));
+    if (longname) {
+        link = link.replace(longname, resolvedName);
+    }
     ?>
-<span class="param-type"><?js= self.linkto(name, self.htmlsafe(resolvedName))?></span>
+<span class="param-type"><?js= link + " " + self.htmlsafe(longname)?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -3,7 +3,7 @@
     var self = this;
     data.forEach(function(name, i) {
     if (env && env.conf && env.conf.docdash && env.conf.docdash.shortenTypes === true) {
-        var nameArr = name.split(".");
+        var nameArr = name.split(/[\.~#]/);
         var resolvedName = nameArr[nameArr.length - 1];
     } else {
         var resolvedName = name;

--- a/tmpl/type.tmpl
+++ b/tmpl/type.tmpl
@@ -17,6 +17,6 @@
         link = link.replace(longname, resolvedName);
     }
     ?>
-<span class="param-type"><?js= link + " " + self.htmlsafe(longname)?></span>
+<span class="param-type"><?js= link?></span>
 <?js if (i < data.length-1) { ?>|<?js } ?>
 <?js }); ?>


### PR DESCRIPTION
I noticed typedefs only show up in the global part of the nav with the typedef option, but it is not uncommon to have typedefs added to a namespace for grouping. This adds those in to each member grouping as well and styles all typedefs with a ● for visual clarity as well.