### PR TITLE
Adding typedefs for members as well and styling.

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -332,6 +332,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
             var displayName;
             var methods = find({kind:'function', memberof: item.longname});
             var members = find({kind:'member', memberof: item.longname});
+            var typedefs = find({kind:'typedef', memberof: item.longname});
             var conf = env && env.conf || {};
             var classes = '';
 
@@ -392,6 +393,22 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                         navItem += "</li>";
 
                         itemsNav += navItem;
+                    });
+
+                    itemsNav += "</ul>";
+                }
+
+                if (docdash.typedefs && typedefs.find(function (m) { return m.scope === 'static'; } )) {
+                    itemsNav += "<ul class='typedefs'>";
+
+                    typedefs.forEach(function (typedef) {
+                        if (!typedef.scope === 'static') return;
+                        itemsNav += "<li data-type='typedef'";
+                        if(docdash.collapse)
+                            itemsNav += " style='display: none;'";
+                        itemsNav += ">";
+                        itemsNav += linkto(typedef.longname, typedef.name);
+                        itemsNav += "</li>";
                     });
 
                     itemsNav += "</ul>";
@@ -469,7 +486,7 @@ function buildNav(members) {
 
         members.globals.forEach(function(g) {
             if ( (docdash.typedefs || g.kind !== 'typedef') && !hasOwnProp.call(seen, g.longname) ) {
-                globalNav += '<li>' + linkto(g.longname, g.name) + '</li>';
+                globalNav += '<li data-type="typedef">' + linkto(g.longname, g.name) + '</li>';
             }
             seen[g.longname] = true;
         });

--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -713,6 +713,17 @@ html[data-search-mode] .level-hide {
   margin-right: 5px;
 }
 
+/** Add a '●' to typedef static members */
+[data-type="typedef"] a::before {
+  content: '\25CF';
+  font-size: .55rem;
+  position: relative;
+  top: -2px;
+  display: inline-block;
+  margin-left: -14px;
+  margin-right: 5px;
+}
+
 #disqus_thread{
     margin-left: 30px;
 }


### PR DESCRIPTION
I noticed typedefs only show up in the global part of the nav with the typedef option, but it is not uncommon to have typedefs added to a namespace for grouping. This adds those in to each member grouping as well and styles all typedefs with a ● for visual clarity as well.