### PR TITLE
feature: updated taffydb link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Docdash
 [![Build Status](https://api.travis-ci.org/clenemt/docdash.png?branch=master)](https://travis-ci.org/clenemt/docdash) [![npm version](https://badge.fury.io/js/docdash.svg)](https://badge.fury.io/js/docdash) [![license](https://img.shields.io/npm/l/docdash.svg)](LICENSE.md)
 
-A clean, responsive documentation template theme for JSDoc 3.
+A clean, responsive documentation template theme for JSDoc 4.
 
 ![docdash-screenshot](https://cloud.githubusercontent.com/assets/447956/13398144/4dde7f36-defd-11e5-8909-1a9013302cb9.png)
 
@@ -135,16 +135,6 @@ Place them anywhere inside your `jsdoc.json` file.
 
 ## Contributors
 
-[![0](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/0)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/0)
-[![1](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/1)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/1)
-[![2](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/2)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/2)
-[![3](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/3)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/3)
-[![4](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/4)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/4)
-[![5](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/5)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/5)
-[![6](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/6)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/6)
-[![7](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/images/7)](https://sourcerer.io/fame/ar2rsawseen/clenemt/docdash/links/7)
-
-## Thanks
 Thanks to [lodash](https://lodash.com) and [minami](https://github.com/nijikokun/minami).
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docdash",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "A clean, responsive documentation template theme for JSDoc 3 inspired by lodash and minami",
   "main": "publish.js",
   "scripts": {
@@ -13,8 +13,8 @@
     "url": "https://github.com/clenemt/docdash.git"
   },
   "devDependencies": {
-    "jsdoc": "latest",
     "browser-sync": "latest",
+    "jsdoc": "latest",
     "watch-run": "latest"
   },
   "author": "Clement Moron <clement.moron@gmail.com>",
@@ -27,5 +27,8 @@
     "publish.js",
     "static",
     "tmpl"
-  ]
+  ],
+  "dependencies": {
+    "@jsdoc/salty": "^0.2.1"
+  }
 }

--- a/publish.js
+++ b/publish.js
@@ -6,7 +6,7 @@ var fs = require('jsdoc/fs');
 var helper = require('jsdoc/util/templateHelper');
 var logger = require('jsdoc/util/logger');
 var path = require('jsdoc/path');
-var taffy = require('taffydb').taffy;
+var taffy = require('@jsdoc/salty').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 


### PR DESCRIPTION
updated the link for taffydb in order for it work for JSDoc v4+ // added dependency package needed // version 2.0.0

BREAKING CHANGE: updated for JSDoc v4+

Fixes #109 