### PR TITLE
Fix:  can hop to anchor links that occur towards the end of the page

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -311,6 +311,7 @@ footer {
   margin-left: 250px;
   display: block;
   padding: 15px;
+  padding-bottom: 100vh;
   font-style: italic;
   font-size: 90%;
 }


### PR DESCRIPTION
**Problem:**

You can't hop to anchor links that occur towards the end of the page if there is not enough room below them. Problem is even more pronounced when using vertical, "portrait" monitors.
![Screenshot 2024-06-13 at 14 13 35](https://github.com/clenemt/docdash/assets/1122333/1ab4ca43-0429-4a82-b5d8-f0bb6b724de6)

**Solution:**

Add white space to the bottom of the footer that is always equal to 100vh (the height of the page in the browser window). This enables the user to always be able to access anchor points at the bottom of the page